### PR TITLE
Fix bug in RemedyOnDemand.js when running test-module

### DIFF
--- a/Packs/Remedy-On-Demand/Integrations/RemedyOnDemand/RemedyOnDemand.js
+++ b/Packs/Remedy-On-Demand/Integrations/RemedyOnDemand/RemedyOnDemand.js
@@ -257,7 +257,7 @@ var fetchIncidentsToDemisto = function() {
 
 switch (command) {
     case 'test-module':
-        fetchIncidents(query=null, test_module=true);
+        fetchIncidents(args={}, test_module=true);
         return 'ok';
     case 'fetch-incidents':
         return fetchIncidentsToDemisto();


### PR DESCRIPTION
if test-module ran, then pass `args={}` to fetchIncidents instead of `query=null`

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Contributing to Cortex XSOAR Content
Make sure to register your contribution by filling the [contribution registration form](https://forms.gle/XDfxU4E61ZwEESSMA)

**The Pull Request will be reviewed only after the contribution registration form is filled.**

## Status
- [x] In Progress
- [ ] Ready
- [ ] In Hold - (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
Fixes a bug within the RemedyOnDemand integration observed when running test-module

## Screenshots
Paste here any images that will help the reviewer

## Minimum version of Cortex XSOAR
- [ ] 6.0.0
- [ ] 6.1.0
- [ ] 6.2.0
- [ ] 6.5.0

## Does it break backward compatibility?
   - [ ] Yes
       - Further details:
   - [x] No

## Must have
- [ ] Tests
- [ ] Documentation 
